### PR TITLE
Handle No-Mailserver

### DIFF
--- a/src/scheduler/smtpserver/SmtpServer.cpp
+++ b/src/scheduler/smtpserver/SmtpServer.cpp
@@ -15,7 +15,7 @@ void SmtpServer::sendMail(const std::string & mail, const std::string & subject,
 
   auto socket = smtps ? Net::TLSSocket::Connect(mailserver.data(), port, true) : Net::Socket::Connect(mailserver.data(), port);
   if(!socket) {
-    throw std::runtime_error("Failed to connect to Mailserver (" + mailserver + ":" + std::to_string(port)));
+    throw std::runtime_error("Failed to connect to Mailserver (" + mailserver + ":" + std::to_string(port) + ")");
   }
   auto in = socket->GetInputStream();
   auto out = socket->GetOutputStream();

--- a/src/scheduler/smtpserver/SmtpServer.cpp
+++ b/src/scheduler/smtpserver/SmtpServer.cpp
@@ -14,6 +14,9 @@ void SmtpServer::sendMail(const std::string & mail, const std::string & subject,
   char        szBuffer[4096]       = "";
 
   auto socket = smtps ? Net::TLSSocket::Connect(mailserver.data(), port, true) : Net::Socket::Connect(mailserver.data(), port);
+  if(!socket) {
+    throw std::runtime_error("Failed to connect to Mailserver (" + mailserver + ":" + std::to_string(port)));
+  }
   auto in = socket->GetInputStream();
   auto out = socket->GetOutputStream();
 


### PR DESCRIPTION
```Thread 11 "bbs" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ffff0c19700 (LWP 9467)]
0x00007ffff7f4fd24 in pthread_mutex_lock () from /usr/lib/libpthread.so.0
(gdb) bt
#0  0x00007ffff7f4fd24 in pthread_mutex_lock () from /usr/lib/libpthread.so.0
#1  0x00007ffff746fd96 in std::__1::mutex::lock() () from /home/christopherhomberger/Downloads/bb/bin/../lib/libc++.so.1
#2  0x00007ffff7fb3567 in Net::Socket::GetInputStream() () from /home/christopherhomberger/Downloads/bb/bin/../lib/libNet.so
#3  0x0000000000280961 in balancedbanana::scheduler::SmtpServer::sendMail(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) ()
#4  0x000000000026ef1c in balancedbanana::scheduler::Scheduler::processCommandLineArguments(int, char const* const*)::QueueObserver::OnUpdate(balancedbanana::scheduler::Observable<balancedbanana::scheduler::JobObservableEvent>*, balancedbanana::scheduler::JobObservableEvent) ()
#5  0x000000000027c04f in balancedbanana::scheduler::Job::setStatus(balancedbanana::database::JobStatus) ()
#6  0x000000000028501e in balancedbanana::scheduler::SchedulerWorkerMP::processTaskMessage(balancedbanana::communication::TaskMessage const&) ()
#7  0x00000000002a1cd9 in balancedbanana::communication::Communicator::msghandler(std::__1::shared_ptr<Net::Socket>, std::__1::shared_ptr<balancedbanana::communication::MessageProcessor>, std::__1::shared_ptr<std::__1::atomic<bool> >) ()
#8  0x00000000002a296f in std::__1::__invoke<void (*&)(std::__1::shared_ptr<Net::Socket>, std::__1::shared_ptr<balancedbanana::communication::MessageProcessor>, std::__1::shared_ptr<std::__1::atomic<bool> >), std::__1::shared_ptr<Net::Socket>&, std::__1::shared_ptr<balancedbanana::communication::MessageProcessor>&, std::__1::shared_ptr<std::__1::atomic<bool> >&> ()
#9  0x00000000002a28af in void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, std::__1::__bind<void (*)(std::__1::shared_ptr<Net::Socket>, std::__1::shared_ptr<balancedbanana::communication::MessageProcessor>, std::__1::shared_ptr<std::__1::atomic<bool> >), std::__1::shared_ptr<Net::Socket> const&, std::__1::shared_ptr<balancedbanana::communication::MessageProcessor> const&, std::__1::shared_ptr<std::__1::atomic<bool> >&> > >(void*) ()
#10 0x00007ffff7f4d46f in start_thread () from /usr/lib/libpthread.so.0
#11 0x00007ffff71483d3 in clone () from /usr/lib/libc.so.6```